### PR TITLE
Resolves #51: Allows specifying non-default tenant domain/ID

### DIFF
--- a/setup_terraform.py
+++ b/setup_terraform.py
@@ -1,8 +1,10 @@
 #! /usr/bin/env python3
 import argparse
+import base64
 import coloredlogs
 import getpass
 import hcl
+import json
 import logging
 import os
 from azure.identity import InteractiveBrowserCredential
@@ -11,20 +13,52 @@ from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.mgmt.storage import StorageManagementClient
 
 
+def get_tenant_id(credential):
+    """
+    Gets the tenant id from a credential's JWT Token.
+
+    Reference: https://jwt.io/
+    """
+    token = credential.get_token("https://graph.microsoft.com/.default")
+    token_parts = token.token.split(".")
+    payload = token_parts[1] + "=="
+    decoded_payload = base64.urlsafe_b64decode(payload).decode("utf-8")
+    token_claims = json.loads(decoded_payload)
+    tenant_id = token_claims.get("tid")
+
+    return tenant_id
+
+
 def get_azure_ids(credential, subscription_name):
     """Get subscription and tenant IDs"""
     # Connect to Azure clients
     subscription_client = SubscriptionClient(credential=credential)
+    tenant_id = get_tenant_id(credential)
+    logging.info(
+        f"Tenancy selected: {tenant_id}"
+    )
 
     # Check that the Azure credentials are valid
     try:
+        subscription_list = list(subscription_client.subscriptions.list())
+        if not len(subscription_list):
+            raise Exception(f"""No subscriptions found in this tenancy.
+                    Verify subscription is under this tenancy: {tenant_id},
+                    if not, specify tenant_id with `-tid` flag.""")
+
+        subscription_id = ""
         for subscription in subscription_client.subscriptions.list():
-            logging.debug(
+            logging.info(
                 f"Found subscription {subscription.display_name} ({subscription.id})"
             )
             if subscription.display_name == subscription_name:
                 subscription_id = subscription.subscription_id
                 tenant_id = subscription.tenant_id
+
+        if not subscription_id:
+            raise ValueError(f"""Specified subscription not found in this tenancy.
+                    Verify subscription is under this tenancy: {tenant_id},
+                    if not, specify tenant_id with `-tid` flag.""")
         logging.info(
             f"Successfully authenticated using: {credential.__class__.__name__}"
         )
@@ -213,6 +247,15 @@ def main():
         help="Name of the Azure storage container",
     )
     parser.add_argument(
+        "-td",
+        "--tenant-id",
+        type=str,
+        default="",
+        help="""Either the `tenant domain` or `Tenant (Directory) ID` to use for subscription.
+        Azure will resolve the domain name to the corresponding tenant ID automatically.
+        e.g. exampledomain.ac.uk""",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="count",
@@ -250,7 +293,11 @@ def main():
     storage_container_name = args.azure_storage_container_name
 
     # Get a common Azure information
-    credential = InteractiveBrowserCredential()
+    if args.tenant_id:
+        credential = InteractiveBrowserCredential(tenant_id=args.tenant_id)
+    else:
+        # This defaults to the "organisations" tenant
+        credential = InteractiveBrowserCredential()
     subscription_id, tenant_id = get_azure_ids(credential, args.azure_subscription_name)
 
     # Configure the Terraform backend

--- a/setup_terraform.py
+++ b/setup_terraform.py
@@ -44,7 +44,7 @@ def get_azure_ids(credential, subscription_name):
         if not len(subscription_list):
             raise Exception(f"""No subscriptions found in this tenancy.
                     Verify subscription is under this tenancy: {tenant_id},
-                    if not, specify tenant_id with `-tid` flag.""")
+                    if not, specify tenant_id with `-td` flag.""")
 
         subscription_id = ""
         for subscription in subscription_client.subscriptions.list():
@@ -58,7 +58,7 @@ def get_azure_ids(credential, subscription_name):
         if not subscription_id:
             raise ValueError(f"""Specified subscription not found in this tenancy.
                     Verify subscription is under this tenancy: {tenant_id},
-                    if not, specify tenant_id with `-tid` flag.""")
+                    if not, specify tenant_id with `-td` flag.""")
         logging.info(
             f"Successfully authenticated using: {credential.__class__.__name__}"
         )

--- a/setup_terraform.py
+++ b/setup_terraform.py
@@ -34,7 +34,7 @@ def get_azure_ids(credential, subscription_name):
     # Connect to Azure clients
     subscription_client = SubscriptionClient(credential=credential)
     tenant_id = get_tenant_id(credential)
-    logging.info(
+    logging.debug(
         f"Tenancy selected: {tenant_id}"
     )
 
@@ -48,7 +48,7 @@ def get_azure_ids(credential, subscription_name):
 
         subscription_id = ""
         for subscription in subscription_client.subscriptions.list():
-            logging.info(
+            logging.debug(
                 f"Found subscription {subscription.display_name} ({subscription.id})"
             )
             if subscription.display_name == subscription_name:


### PR DESCRIPTION
Fixes #51 

Updates to `setup_terraform.py`:
* Find and log the tenancy ID upon login for debugging.
* Allow specifying the tenancy to log in with.
    * This can be via either the tenancy domain (`example.ac.uk`) or the corresponding tenant ID (`5465f4-f168-...`)
      * Find tenant domain/id's you have access to [here](https://portal.azure.com/#settings/directory)
    * Example using the new flag: `./setup_terraform.py -td example.ac.uk ...` along with rest of the required flags.
* Raises exceptions if:
  * No subscriptions found in tenancy.
  * Requested subscription not found in tenancy.