### PR TITLE
Fix #54: Update azurerm provider to newer version

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -6,7 +6,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.59.0"
+      version = "=3.90.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
Resolves #54 

Update `azurerm` provider version from `3.59.0` to `3.90.0` which does not have deprecated `Microsoft.TimeSeriesInsights`.

Following this [comment](https://github.com/hashicorp/terraform-provider-azurerm/issues/27466#issuecomment-2368984564).