### PR TITLE
Fix #55: Enable flag to build dependencies during deployment

### DIFF
--- a/terraform/application/app.tf
+++ b/terraform/application/app.tf
@@ -32,7 +32,7 @@ resource "azurerm_linux_web_app" "this" {
     "ICENET_AUTH_LIST"        = "/data/auth_list.json"
     "ICENET_DATA_LOCATION"    = "/data"
 #    "ENABLE_ORYX_BUILD"              = "true"
-#    "SCM_DO_BUILD_DURING_DEPLOYMENT" = "true"
+    "SCM_DO_BUILD_DURING_DEPLOYMENT" = "true"
   }
 
   storage_account {


### PR DESCRIPTION
Resolves #55 

Enables `SCM_DO_BUILD_DURING_DEPLOYMENT` flag to allow requirements.txt to be installed during deployment.

Fixes the issue of missing `pandas` upon deployment.