### PR TITLE
Use built in Azure role to reduce required permissions for terraform

### DIFF
--- a/terraform/forecast_processor/functions.tf
+++ b/terraform/forecast_processor/functions.tf
@@ -140,27 +140,9 @@ resource "azurerm_linux_function_app" "this" {
   }
 }
 
-resource "azurerm_role_definition" "app_data_read" {
-  description        = "Allows for read access to Azure Storage blob containers and data"
-  name               = "${local.app_name}-role-read-forecast-data"
+resource "azurerm_role_assignment" "storage_blob_data_reader_assoc" {
   scope              = var.data_storage_account.id
-
-  permissions {
-      actions          = [
-          "Microsoft.Storage/storageAccounts/blobServices/containers/read",
-          "Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey/action",
-      ]
-      data_actions     = [
-          "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
-      ]
-      not_actions      = []
-      not_data_actions = []
-  }
-}
-
-resource "azurerm_role_assignment" "app_data_read_assoc" {
-  scope              = var.data_storage_account.id
-  role_definition_id = azurerm_role_definition.app_data_read.role_definition_resource_id
+  role_definition_name = "Storage Blob Data Reader"
   principal_id       = azurerm_linux_function_app.this.identity.0.principal_id
 }
 


### PR DESCRIPTION
This PR removes the requirement for the user applying the terraform configuration to have the `Microsoft.Authorization/roleDefinitions/write` permission.

The aim is to make it possible to run terraform as a user with minimal additional permissions over those of a Contributer (and ideally less than a full Administrator).

Currently, running the terraform configuration requires the following permissions that a 'Contributor' does not already have:
- `Microsoft.Authorization/roleAssignments/write` (and maybe `delete`)
- `Microsoft.Authorization/roleDefinitions/write` (and maybe `delete`)

A [Role Based Access Administrator](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/privileged#role-based-access-control-administrator) has the first of these, but still would not be able to create a custom role.  It can be further [limited by a condition](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal#step-5-(optional)-add-condition).

The "app_data_read" role is equivalent to the built-in role "Storage Blob Data Reader", except for the former's limited scope, so one solution is to use this to avoid needing `roleDefinitions/write`.  The scope is specified when the role is applied, so the permission granted to the app is the same.

### To do

- [X] Check that the terraform generates the expected plan
- [ ] Check `terraform apply` (I'm unable to do this currently as I am only a Contributor to the subscription I have access to)

